### PR TITLE
Added to KiCAD PCM

### DIFF
--- a/.github/workflows/kicad-pcm.yml
+++ b/.github/workflows/kicad-pcm.yml
@@ -42,6 +42,6 @@ jobs:
         with:
           workflow: Rebuild repository
           ref: refs/heads/main
-          repo: Bouni/bouni-kicad-repository
+          repo: hlord2000/hlord2000-kicad-repository
           token: ${{ secrets.PERSONAL_TOKEN }}
           inputs: '{ "VERSION": "${{env.VERSION}}", "DOWNLOAD_SHA256": "${{env.DOWNLOAD_SHA256}}", "DOWNLOAD_SIZE": "${{env.DOWNLOAD_SIZE}}", "DOWNLOAD_URL": "${{env.DOWNLOAD_URL}}", "INSTALL_SIZE": "${{env.INSTALL_SIZE}}" }'

--- a/.github/workflows/kicad-pcm.yml
+++ b/.github/workflows/kicad-pcm.yml
@@ -42,6 +42,6 @@ jobs:
         with:
           workflow: Rebuild repository
           ref: refs/heads/main
-          repo: hlord2000/kicad-kle-placer
+          repo: Bouni/bouni-kicad-repository
           token: ${{ secrets.PERSONAL_TOKEN }}
           inputs: '{ "VERSION": "${{env.VERSION}}", "DOWNLOAD_SHA256": "${{env.DOWNLOAD_SHA256}}", "DOWNLOAD_SIZE": "${{env.DOWNLOAD_SIZE}}", "DOWNLOAD_URL": "${{env.DOWNLOAD_URL}}", "INSTALL_SIZE": "${{env.INSTALL_SIZE}}" }'

--- a/.github/workflows/kicad-pcm.yml
+++ b/.github/workflows/kicad-pcm.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Get latest tag
         uses: oprypin/find-latest-tag@v1
         with:
-          repository:  Bouni/kicad-jlcpcb-tools
+          repository:  zykrah/kicad-kle-placer
           releases-only: true
         id: latest-release
         

--- a/PCM/create_pcm_archive.sh
+++ b/PCM/create_pcm_archive.sh
@@ -1,0 +1,46 @@
+#!/bin/sh
+
+# heavily inspired by https://github.com/4ms/4ms-kicad-lib/blob/master/PCM/make_archive.sh
+
+VERSION=$1
+
+echo "Clean up old files"
+rm -f PCM/*.zip
+rm -rf PCM/archive
+
+
+echo "Create folder structure for ZIP"
+mkdir -p PCM/archive/plugins
+mkdir -p PCM/archive/resources
+
+echo "Copy files to destination"
+cp VERSION PCM/archive/plugins
+cp *.py PCM/archive/plugins
+cp *.png PCM/archive/plugins
+cp settings.json PCM/archive/plugins
+cp -r icons PCM/archive/plugins
+cp PCM/icon.png PCM/archive/resources
+cp PCM/metadata.template.json PCM/archive/metadata.json
+
+echo "Write version info to file"
+echo $VERSION > PCM/archive/plugins/VERSION
+
+echo "Modify archive metadata.json"
+sed -i "s/VERSION_HERE/$VERSION/g" PCM/archive/metadata.json
+sed -i "s/\"kicad_version\": \"6.0\",/\"kicad_version\": \"6.0\"/g" PCM/archive/metadata.json
+sed -i "/SHA256_HERE/d" PCM/archive/metadata.json
+sed -i "/DOWNLOAD_SIZE_HERE/d" PCM/archive/metadata.json
+sed -i "/DOWNLOAD_URL_HERE/d" PCM/archive/metadata.json
+sed -i "/INSTALL_SIZE_HERE/d" PCM/archive/metadata.json
+
+echo "Zip PCM archive"
+cd PCM/archive
+zip -r ../KiCAD-PCM-$VERSION.zip .
+cd ../..
+
+echo "Gather data for repo rebuild"
+echo VERSION=$VERSION >> $GITHUB_ENV
+echo DOWNLOAD_SHA256=$(shasum --algorithm 256 PCM/KiCAD-PCM-$VERSION.zip | xargs | cut -d' ' -f1) >> $GITHUB_ENV
+echo DOWNLOAD_SIZE=$(ls -l PCM/KiCAD-PCM-$VERSION.zip | xargs | cut -d' ' -f5) >> $GITHUB_ENV
+echo DOWNLOAD_URL="https:\/\/github.com\/Bouni\/kicad-jlcpcb-tools\/releases\/download\/$VERSION\/KiCAD-PCM-$VERSION.zip" >> $GITHUB_ENV
+echo INSTALL_SIZE=$(unzip -l PCM/KiCAD-PCM-$VERSION.zip | tail -1 | xargs | cut -d' ' -f1) >> $GITHUB_ENV

--- a/PCM/create_pcm_archive.sh
+++ b/PCM/create_pcm_archive.sh
@@ -42,5 +42,5 @@ echo "Gather data for repo rebuild"
 echo VERSION=$VERSION >> $GITHUB_ENV
 echo DOWNLOAD_SHA256=$(shasum --algorithm 256 PCM/KiCAD-PCM-$VERSION.zip | xargs | cut -d' ' -f1) >> $GITHUB_ENV
 echo DOWNLOAD_SIZE=$(ls -l PCM/KiCAD-PCM-$VERSION.zip | xargs | cut -d' ' -f5) >> $GITHUB_ENV
-echo DOWNLOAD_URL="https:\/\/github.com\/Bouni\/kicad-jlcpcb-tools\/releases\/download\/$VERSION\/KiCAD-PCM-$VERSION.zip" >> $GITHUB_ENV
+echo DOWNLOAD_URL="https:\/\/github.com\/hlord2000\/kicad-kle-placer\/releases\/download\/$VERSION\/KiCAD-PCM-$VERSION.zip" >> $GITHUB_ENV
 echo INSTALL_SIZE=$(unzip -l PCM/KiCAD-PCM-$VERSION.zip | tail -1 | xargs | cut -d' ' -f1) >> $GITHUB_ENV

--- a/PCM/metadata.template.json
+++ b/PCM/metadata.template.json
@@ -1,0 +1,33 @@
+{
+    "$schema": "https://go.kicad.org/pcm/schemas/v1",
+    "name": "KiCAD KLE Placer",
+    "description": "A plugin for KiCAD used to place switches based on a KLE.",
+    "description_full": "This plugin allows you to automatically place footprints of your chosing from a generated KLE .json file.",
+    "identifier": "com.github.zykrah.kicad-kle-placer",
+    "type": "plugin",
+    "author": {
+        "name": "zykrah",
+        "contact": {
+            "github": "zykrah"
+        }
+    },
+    "maintainer": {
+        "name": "zykrah",
+        "contact": {
+            "github": "zykrah"
+        }
+    },
+    "license": "UNKNOWN",
+    "resources": {
+        "homepage": "https://github.com/zykrah/kicad-kle-placer"
+    },
+    "versions": [{
+        "version": "VERSION_HERE",
+        "status": "testing",
+        "kicad_version": "6.0",
+        "download_sha256": "SHA256_HERE",
+        "download_size": DOWNLOAD_SIZE_HERE,
+        "download_url": "DOWNLOAD_URL_HERE",
+        "install_size": INSTALL_SIZE_HERE
+    }]
+}

--- a/PCM/metadata.template.json
+++ b/PCM/metadata.template.json
@@ -17,7 +17,7 @@
             "github": "zykrah"
         }
     },
-    "license": "UNKNOWN",
+    "license": "WTFPL",
     "resources": {
         "homepage": "https://github.com/zykrah/kicad-kle-placer"
     },


### PR DESCRIPTION
Tested on KiCAD 6.0.

Based on https://github.com/Bouni/bouni-kicad-repository and https://github.com/Bouni/kicad-jlcpcb-tools

A personal access token must be added to the environment for actions/workflows to work. 
https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token
That token will need access to GitHub actions.

Changes must be made in master/PCM/create_pcm_archive.sh and master/.github/workflows/kicad-pcm.yml per your repository name. For testing, I used my own fork of the kicad-repo that can be found here:
https://github.com/hlord2000/hlord2000-kicad-repository

<img width="462" alt="image" src="https://user-images.githubusercontent.com/36466317/179056105-4553ccbb-b0e4-45b8-bd37-add03cb3ba76.png">
<img width="361" alt="image" src="https://user-images.githubusercontent.com/36466317/179056187-ddfb01cc-28b8-4842-9ccb-fbe987aca892.png">
<img width="416" alt="image" src="https://user-images.githubusercontent.com/36466317/179056214-8b822ae4-aa51-44fb-9e6c-0cd6117dde00.png">
