### PR TITLE
Fix None Check Using 'is' vs '=='

### DIFF
--- a/kle_placer_action.py
+++ b/kle_placer_action.py
@@ -133,7 +133,7 @@ class BoardModifier():
     def get_footprint(self, reference, required=True) -> FOOTPRINT:
         self.logger.info("Searching for {} footprint".format(reference))
         footprint = self.board.FindFootprintByReference(reference)
-        if footprint == None and required:
+        if footprint is None and required:
             self.logger.error("Footprint not found")
             raise Exception("Cannot find footprint {}".format(reference))
         return footprint


### PR DESCRIPTION
This fixes the footprint check, after FindFootprintByReference, this was using == to check but this is broken in the latest 8.0.2 release of KiCad, you need to use the 'is' instead.

Without this change the plugin will always fail (on MacOS at least). 